### PR TITLE
Dev

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -23,6 +23,7 @@
  */
 
 require_once(dirname(dirname(__FILE__)) . '../../config.php');
+require_once($CFG->dirroot.'/blocks/bulkactivity/locallib.php');
 
 defined('MOODLE_INTERNAL') || die();
 require_login();
@@ -79,7 +80,7 @@ function getcategories($parentid) {
         $sql = "select id,name from {course_categories} where coursecount > ? and visible =? and parent =?";
         return $categories = $DB->get_records_sql($sql,$parm);
     }elseif(!empty($catstr)){
-       
+
         list($insql, $inparams) = $DB->get_in_or_equal($parentcat);
           $parm =   array_merge($inparams,$parm);
            $sql = "SELECT id,name FROM {course_categories} WHERE id $insql and coursecount > ? and visible =? and parent =?";
@@ -88,9 +89,10 @@ function getcategories($parentid) {
 
 }
 
-function courselist($category, $course, $checked,$parm) {
-    global $DB,$USER;
+function courselist($category, $course, $checked, $parm, $selectedcourses=[]) {
+    global $DB, $USER, $CFG;
 
+    $bsattrs = block_bulkactivity_bs_attrs();
 
     $parm[] = 1;
     $usercoursess = enrol_get_users_courses($USER->id, true, Null, 'visible DESC,sortorder ASC');
@@ -119,7 +121,7 @@ function courselist($category, $course, $checked,$parm) {
 				<div class="panel-heading categorydiv" id="category_' . $category . '_' . $chidld->id . '" >
 				<h3 class="panel-title categoryname">
 				<input type="checkbox" value="1" id="checkall_' . $category . '_' . $chidld->id . '" class="checkall">
-				<a data-toggle="collapse"    aria-expanded="true" aria-controls="collapse_' . $category . '_' . $chidld->id . '"  href="#collapse_' . $category . '_' . $chidld->id . '">
+				<a ' . $bsattrs['toggle'] . '="collapse"    aria-expanded="true" aria-controls="collapse_' . $category . '_' . $chidld->id . '"  href="#collapse_' . $category . '_' . $chidld->id . '">
 				<i class="indicator indicatorerro' . $category . $chidld->id . ' fa fa-caret-right"  id="indicatorerro_' . $category . '' . $chidld->id . '" aria-hidden="true" ></i> ' . $chidld->name . '
 				</a>
 				</h3>
@@ -136,7 +138,7 @@ function courselist($category, $course, $checked,$parm) {
 
     foreach ($courses as $course) {
 
-        // Get course sections 
+        // Get course sections
         $course_sections = $DB->get_records_sql("select id,section,name from {course_sections} where course=".$course->id." and visible = 1");
         $selection_html = "<option value='-1'>-- Select Section --</option>";
         foreach($course_sections as $course_section){
@@ -150,10 +152,19 @@ function courselist($category, $course, $checked,$parm) {
             }
             $selection_html .= "<option value='".$course_section->id."' >".$section_name."</option>";
         }
+
+        // Course is already selected so make the course as selected.
+        $coursechecked = $checked;
+        $sectionstatus = 'hidden';
+        if (in_array($course->id, $selectedcourses)) {
+            $coursechecked = 'checked';
+            $sectionstatus = 'visible';
+        }
+
         $courselist .= '<div class="col-md-6 custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" name="course[]" value="' . $course->id . '" id="customCheck' . $course->id . '" ' . $checked . ' onclick="courseChecked(this);" > <!-- Added checked in the checkbox-->
+            <input type="checkbox" class="custom-control-input" name="course[]" value="' . $course->id . '" id="customCheck' . $course->id . '" ' . $coursechecked . ' onclick="courseChecked(this);" > <!-- Added checked in the checkbox-->
             <label class="custom-control-label" for="customCheck' . $course->id . '">' . $course->fullname . '</label>
-            <select name="coursesection_'.$course->id.'" id="coursesection_'.$course->id.'" style="visibility: hidden;" >'.$selection_html.'</select>
+            <select name="coursesection_'.$course->id.'" id="coursesection_'.$course->id.'" style="visibility: ' . $sectionstatus . ';" >'.$selection_html.'</select>
 			</div>';
     }
     return $courselist;
@@ -163,7 +174,9 @@ if ($request == 'getcagegorycourse') {
     $categoryid = required_param('categoryid', PARAM_INT);
     $currentcourseid = required_param('currentcourseid', PARAM_INT);
     $checked = required_param('checked', PARAM_BOOL);
+    $selectedcourses = optional_param_array('selectedcourses', [], PARAM_INT);
+
     $parm  =array($currentcourseid,$categoryid);
-    echo courselist($categoryid, $currentcourseid, $checked,$parm);
+    echo courselist($categoryid, $currentcourseid, $checked, $parm, $selectedcourses);
     exit;
 }

--- a/block_bulkactivity.php
+++ b/block_bulkactivity.php
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die();
 class block_bulkactivity extends block_base {
     public function init() {
         $this->title = get_string('pluginname', __CLASS__);
-        $this->version = 2015012700;
+
     }
 
     public function applicable_formats() {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "doiphode/moodle-block_bulkactivity",
+    "type": "moodle-block",
+    "require": {
+        "composer/installers": "~1.0"
+    },
+    "extra": {
+        "installer-name": "bulkactivity"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,0 @@
-{
-    "name": "doiphode/moodle-block_bulkactivity",
-    "type": "moodle-block",
-    "extra": {
-        "installer-name": "bulkactivity"
-    }
-}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,6 @@
 {
     "name": "doiphode/moodle-block_bulkactivity",
     "type": "moodle-block",
-    "require": {
-        "composer/installers": "~1.0"
-    },
     "extra": {
         "installer-name": "bulkactivity"
     }

--- a/createbulkactivities.php
+++ b/createbulkactivities.php
@@ -52,7 +52,7 @@ $PAGE->set_pagelayout('admin');
 $PAGE->set_title(get_string("pluginname", "block_bulkactivity"));
 $PAGE->set_heading(get_string("pluginname", "block_bulkactivity"));
 //$PAGE->navbar->ignore_active();
-$PAGE->set_url($CFG->wwwroot . "/blocks/bulkactivity/createbulkactivity.php");
+$PAGE->set_url(new moodle_url($CFG->wwwroot . "/blocks/bulkactivity/createbulkactivities.php", ['cba' => $modid]));
 
 $PAGE->requires->jquery();
 //$PAGE->requires->js( new moodle_url('https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js'),true);
@@ -131,7 +131,7 @@ if ($fromdata = $company_form->get_data()) {
     $modid = $fromdata->cmid;
     $coursesearray =optional_param_array('course','', PARAM_INT);
 
-    
+
     if($coursesearray==''){
         $actual_link = new moodle_url('/blocks/bulkactivity/createbulkactivities.php?cba=' . $modid);
         //redirect($actual_link, get_string('selectcourse', 'block_bulkactivity'), '', \core\output\notification::NOTIFY_SUCCESS);
@@ -142,7 +142,7 @@ if ($fromdata = $company_form->get_data()) {
     foreach($fromdata->course as $courseid){
         $coursesection[$courseid] = required_param('coursesection_'.$courseid, PARAM_INT);
     }
-    
+
 
     function duplicate_modulebac($course, $cm,$fromdata,$copyactivityto) {
         global $CFG, $DB, $USER;
@@ -264,8 +264,6 @@ if ($fromdata = $company_form->get_data()) {
         if ($newcmid) {
             // Proceed with activity renaming before everything else. We don't use APIs here to avoid
             // triggering a lot of create/update duplicated events.
-
-
             $newcm = get_coursemodule_from_id($cm->modname, $newcmid, $cm->course);
             // Add ' (copy)' to duplicates. Note we don't cleanup or validate lengths here. It comes
             // from original name that was valid, so the copy should be too.
@@ -276,7 +274,6 @@ if ($fromdata = $company_form->get_data()) {
             if ($cmindex !== false && $cmindex < count($modarray) - 1) {
                 moveto_module_new($newcm, $section, $modarray[$cmindex + 1]);
             }
-
         }
 
         return isset($newcm) ? $newcm : null;
@@ -339,15 +336,22 @@ echo $OUTPUT->footer();
         var checked = false;
         if ($(this).is(":checked")) {
             checked = true;
-            console.log("checked");
         } else {
-            console.log("unchecked");
+            checked = false;
         }
+
+        var collapse = $(this).parent().find('[data-bs-toggle="collapse"]');
 
         setTimeout(function () {
             console.log("id : #collapse_" + postfix);
-            $('#collapse_' + postfix + " input[type=checkbox]").each(function () {
+            // When checkall is clicked if the collapse is not open trigger the click to open the collapse and show the courses.
+            if (checked && collapse && collapse.attr('aria-expanded') == "false") {
+                // collapse.trigger('click');
+                $('#collapse_' + postfix).addClass('show');
+                collapse.attr('aria-expanded', 'true');
+            }
 
+            $('#collapse_' + postfix + " input[type=checkbox]").each(function () {
                 $(this).prop('checked', checked); // Checks it
                 var value = $(this).val();
                 if ($(this).is(':checked')) {
@@ -454,6 +458,20 @@ echo $OUTPUT->footer();
                 checked = "checked";
             }
         }
+
+        // Selected courses.
+        var formdata = new FormData($(this).parents('form')[0]);
+        var selectedcourses = formdata.getAll('course[]');
+
+        var courseSections = {};
+        // Loop through all key-value entries
+        for (const [key, value] of formdata.entries()) {
+            console.log(key, value);
+            if (key.startsWith('coursesection_')) {
+                courseSections[key] = value;
+            }
+        }
+
         $.ajax({
             url: get_action_url('ajax'),
             type: 'POST',
@@ -461,10 +479,17 @@ echo $OUTPUT->footer();
                 'request': 'getcagegorycourse',
                 categoryid: categoryid,
                 currentcourseid: currentcourseid,
-                checked: checked
+                checked: checked,
+                selectedcourses: selectedcourses
             },// Added checked: checked
             success: function (data) {
                 $('#categorycourses_' + coursediv).html(data);
+                $('#categorycourses_' + coursediv).parents('form').find('[name^="coursesection_"]').each(function() {
+                    var nameAttr = $(this).attr('name');
+                    if (courseSections[nameAttr] !== undefined) {
+                        $(this).val(courseSections[nameAttr]);
+                    }
+                });
 
             }
         });

--- a/formslib.php
+++ b/formslib.php
@@ -7,6 +7,7 @@ class compactivity_form extends moodleform
     function definition()
     {
         global $DB, $USER,$CFG,$OUTPUT;
+        $bsattrs = block_bulkactivity_bs_attrs();
         $this->_form = new MoodleQuickForm($this->_formname, 'post', '');
         $categories = $this->_customdata['categories'];
         $courseid = $this->_customdata['courseid'];
@@ -23,11 +24,11 @@ class compactivity_form extends moodleform
 
 						<h3 class="panel-title categoryname" style="font-weight: 100">
                             <input type="checkbox" class="checkall" id="checkall_' . $category->id . '" value="1">&nbsp;
-                            <a data-toggle="collapse"    aria-expanded="true" aria-controls="collapse_' . $category->id . '"  href="#collapse_' . $category->id . '">
+                            <a ' . $bsattrs['toggle'] . '="collapse"    aria-expanded="false" aria-controls="collapse_' . $category->id . '"  href="#collapse_' . $category->id . '">
 								<i class="indicator indicatorerro fa fa-caret-right" id="indicatorerro_' . $category->id . '" aria-hidden="true" ></i> ' . $category->name . '
 							</a>
 						</h3>
-					</div> 
+					</div>
                         <div id="collapse_' . $category->id . '" class="collapse collapsesubcat"  data-parent="#accordion" style="padding-left: 15px;padding-right: 15px;">
                         <div class="card-body" style="padding: 0px;">
                              <div class="form-row checkbox-group required categorycourses" id="categorycourses_' . $category->id . '" >
@@ -44,7 +45,7 @@ class compactivity_form extends moodleform
         $mform->addElement('hidden', 'cmid');
         $mform->setType('cmid', PARAM_INT);
         $mform->addElement('header','displayinfo', get_string('courselistheader', 'block_bulkactivity'));
-        
+
         $mform->addElement('html', $html);
         $mform->addElement('submit', 'submin_but', get_string('submit'));
         $mform->setDefault( 'currentcourseid', $courseid);

--- a/locallib.php
+++ b/locallib.php
@@ -5,6 +5,10 @@ defined('MOODLE_INTERNAL') || die();
 function moveto_module_new($mod, $section, $beforemod=NULL) {
     global $OUTPUT, $DB;
 
+    if (empty($mod) || empty($section)) {
+        return false;
+    }
+
     // Current module visibility state - return value of this function.
     $modvisible = $mod->visible;
 
@@ -27,4 +31,18 @@ function moveto_module_new($mod, $section, $beforemod=NULL) {
     // Add the module into the new section.
     course_add_cm_to_section($section->course, $mod->id, $section->section, $beforemod);
     return $modvisible;
+}
+/**
+ * Get Bootstrap data-* attribute names compatible with the current Moodle version.
+ * Moodle 5.0+ uses Bootstrap 5 (data-bs-toggle / data-bs-parent),
+ * Moodle 4.x uses Bootstrap 4 (data-toggle / data-parent).
+ *
+ * @return array ['toggle' => string, 'parent' => string]
+ */
+function block_bulkactivity_bs_attrs() {
+    global $CFG;
+    if ((int)$CFG->branch >= 500) {
+        return array('toggle' => 'data-bs-toggle', 'parent' => 'data-bs-parent');
+    }
+    return array('toggle' => 'data-toggle', 'parent' => 'data-parent');
 }

--- a/script.js
+++ b/script.js
@@ -24,8 +24,8 @@ require(['jquery'], function ($) {
 
         // @var {Object}  The icon configurations.
         var icon = {
-            'createactivityincourses': {css: 'editing_backupbulk', pix: 'i/twoway'},
-            'backupbulk': {css: 'editing_backupbulk', pix: 'i/twoway'},
+            'createactivityincourses': { css: 'editing_backupbulk', pix: 'i/twoway' },
+            'backupbulk': { css: 'editing_backupbulk', pix: 'i/twoway' },
         };
 
         // @var {Node}  The Bulk Activity block container node.
@@ -137,7 +137,7 @@ require(['jquery'], function ($) {
          * @returns {*|jQuery}
          */
         function add_spinner($node) {
-            var WAITICON = {'pix': 'i/loading_small', 'component': 'moodle'};
+            var WAITICON = { 'pix': 'i/loading_small', 'component': 'moodle' };
 
             if ($node.find('.spinner').length) {
                 return $node.find('.spinner');
@@ -228,7 +228,6 @@ require(['jquery'], function ($) {
 
         $.init_activity_commands = function () {
             function add_backupbulk_comand($activity) {
-                console.log('activity : ' + $activity);
                 var $menu = $activity.find('ul[role=\'menu\']');
 
                 if ($menu.length) {
@@ -247,7 +246,7 @@ require(['jquery'], function ($) {
 
                 } else {
                     var $backupbulk = create_command('createactivityincourses');
-                    $menu = $activity.find('div[role="menu"]');
+                    $menu = $activity.find('div[role="menu"]:not(.dropdown-subpanel-content)');
                     if ($menu.length) {
                         $backupbulk = create_special_activity_command('createactivityincourses');
                         $menu.append($backupbulk.attr('role', 'menuitem'));
@@ -266,18 +265,48 @@ require(['jquery'], function ($) {
             }
 
             // if (course.is_frontpage) {
-                $('.sitetopic li.activity').each(function () {
-                    add_backupbulk_comand($(this));
-                });
-                $('.block_site_main_menu .content > ul > li').each(function () {
-                    add_backupbulk_comand($(this));
-                });
+            $('.sitetopic li.activity').each(function () {
+                add_backupbulk_comand($(this));
+            });
+            $('.block_site_main_menu .content > ul > li').each(function () {
+                add_backupbulk_comand($(this));
+            });
             // } else {
-                $('.course-content li.activity').each(function () {
-                
-                    add_backupbulk_comand($(this));
-                });
+            $('.course-content li.activity').each(function () {
+
+                add_backupbulk_comand($(this));
+            });
             // }
+
+            const observeModuleUpdates = (node) => {
+                add_backupbulk_comand($(node))
+            };
+
+            if (document.querySelector('.course-content') != undefined) {
+                const observer = new MutationObserver((mutations) => {
+                    for (const mutation of mutations) {
+                        // Check added/replaced activity elements
+                        mutation.addedNodes.forEach((node) => {
+                            if (!(node instanceof HTMLElement)) {
+                                return;
+                            }
+
+                            // A whole activity was added
+                            if (node.matches('li.activity')) {
+                                observeModuleUpdates(node);
+                            }
+
+                            // Or activities inside a larger updated block
+                            node.querySelectorAll?.('li.activity').forEach(observeModuleUpdates);
+                        });
+                    }
+                });
+
+                observer.observe(document.querySelector('.course-content'), {
+                    childList: true,
+                    subtree: true
+                });
+            }
         };
 
         /**
@@ -289,7 +318,7 @@ require(['jquery'], function ($) {
             $.init_activity_commands();
         };
 
-        var WAITICON = {'pix': 'i/loading', 'component': 'moodle'};
+        var WAITICON = { 'pix': 'i/loading', 'component': 'moodle' };
         var $spinner = $('<img/>').attr('src', M.util.image_url(WAITICON.pix, WAITICON.component)).addClass('spinner');
         $('div#bulkactivity-spinner-modal div.spinner-container').prepend($spinner);
 

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,13 @@
 
 #blkh3 .form-row {
     margin-left: 22px !important;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+#blkh3 .form-row > .panel-group {
+    width: 100%;
 }
 
 #blkh3 .collapsesubcat {

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024080200;
+$plugin->version = 2026061700;
 $plugin->requires = 2017050500; // Moodle 3.3.
 $plugin->component = 'block_bulkactivity';
-$plugin->release = '4.1, release 2';
+$plugin->release = '4.2, release 2';
 $plugin->maturity = MATURITY_STABLE; // This is considered as ready for production sites.


### PR DESCRIPTION
- Add block_bulkactivity_bs_attrs() helper to switch between BS4
  (data-toggle) and BS5 (data-bs-toggle) attributes based on Moodle
  version ($CFG->branch >= 500), for Moodle 5.0+ compatibility
- Preserve selected courses and chosen sections when switching
  categories via AJAX (selectedcourses param + section restore)
- Auto-open a category's collapse when "check all" is used
- Inject the Bulk Activity command into dynamically rendered
  activities via MutationObserver on .course-content
- Exclude dropdown subpanel menus when injecting the command
- Fix set_url to point to createbulkactivities.php with the cba param
- Guard moveto_module_new() against empty module/section
- Remove deprecated $this->version from block init; bump version.php
  to 2026061700 (release 4.2, release 2)
- Remove composer.json and stray debug logging